### PR TITLE
Link stored procedures to Python – pt1: users

### DIFF
--- a/scripts/db/procs/users.sql
+++ b/scripts/db/procs/users.sql
@@ -1,8 +1,9 @@
 DROP PROCEDURE IF EXISTS add_user;
-DROP PROCEDURE IF EXISTS get_user_by_id;
+DROP PROCEDURE IF EXISTS get_user;
 DROP PROCEDURE IF EXISTS get_user_by_username;
 
 DELIMITER //
+
 CREATE PROCEDURE add_user(
     IN in_username VARCHAR(255),
     IN in_name VARCHAR(255),
@@ -14,9 +15,9 @@ BEGIN
     SELECT LAST_INSERT_ID();
 END //
 
-CREATE PROCEDURE get_user_by_id(IN in_id INT UNSIGNED)
+CREATE PROCEDURE get_user(IN in_identifier VARCHAR(255))
 BEGIN
-    SELECT * FROM users WHERE id = in_id;
+    SELECT * FROM users WHERE CONCAT(id, '') = in_identifier OR username = in_identifier;
 END //
 
 CREATE PROCEDURE get_user_by_username(IN in_username VARCHAR(255))

--- a/src/rickbox/database/database_helper.py
+++ b/src/rickbox/database/database_helper.py
@@ -86,6 +86,16 @@ class DatabaseHelper:
         self._cursor.execute(query=query, args=params or ())
         return self
 
+    def callproc(self, proc_name, params=None):
+        """
+        Execute an sql stored procedure in the database with optional parameters.
+
+        :param proc_name: name of the stored procedure to call
+        :param params: optional parameters to pass with the query
+        """
+        self._cursor.callproc(proc_name, args=params or ())
+        return self
+
     def fetchall(self):
         return self._cursor.fetchall()
 

--- a/src/rickbox/database/models/user.py
+++ b/src/rickbox/database/models/user.py
@@ -1,0 +1,121 @@
+"""
+Object representation for the users table / user entities.
+Acts as the interface between the database and the application.
+
+Usage:
+
+The constructor takes in one required param – username – and two optional
+params – name, and email. Returns a User object with the given properties.
+"""
+
+import json
+
+from database.database_helper import DatabaseHelper
+from util.validators import validate_id
+
+
+class User:
+    id = None
+    username = None
+    name = None
+    email = None
+
+    def __init__(self, id=None, username=None, name=None, email=None):
+        self.id = id
+        self.username = username
+        self.name = name
+        self.email = email
+
+    def save(self):
+        """
+        Commits a User record to the database.
+
+        Returns:
+            If the commit was successful, return the ID of the newly-created User
+
+        Raises:
+            ValueError:
+                - user.id is set (`put` operation is NYI)
+                - user.username is blank (None or '')
+            LookupError:
+                - User record could not be found after saving
+            NameError:
+                - user.username exists in database already
+        """
+        if self.id is not None:
+            # currently only supports saving new records, not updating existing ones
+            raise ValueError('The `User.id` attribute must be None to save a User object.')
+
+        if self.username in (None, ''):
+            raise ValueError('The `User.username` attribute must not be empty to save a User object.')
+
+        if not User.username_available(self.username):
+            # This should probably be some other exception
+            # Maybe some custom ones should be made?
+            raise NameError(f'The username {self.username} is already taken.')
+
+        with DatabaseHelper() as db:
+            db.callproc('add_user', [self.username, self.name, self.email])
+
+        return User.get_by_identifier(self.username, is_username=True).id
+
+    @classmethod
+    def get_by_identifier(cls, identifier, is_username=None):
+        """
+        Query the database for a single User record based on identifier (ID/username).
+
+        :param identifier: the identifier value of the User record to find
+        :param is_username: whether the identifier value represents a username. False implies the identifier is an ID
+
+        Returns:
+            If a user record exists with the given identifier, return that record
+
+        Raises:
+            ValueError:
+                - is_username is None
+                - identifier is None or an empty string
+            LookupError:
+                - no User record with the given identifier exists
+        """
+
+        if is_username is None:
+            raise ValueError('`is_username` must be explicitly set to True or False.')
+
+        if identifier in (None, ''):
+            raise ValueError('`identifier` is a required parameter.')
+
+        if is_username:
+            identifier_type = 'username'
+        else:
+            identifier_type = 'id'
+            identifier = validate_id(identifier)
+
+        stored_proc = f'get_user_by_{identifier_type}'
+
+        # Convert to iterable for PyMySQL
+        identifier = (identifier,)
+        with DatabaseHelper() as db:
+            record = db.callproc(stored_proc, identifier).fetchone()
+            if record is None:
+                raise LookupError(f'No user with the given {identifier_type} exists in the database.')
+
+        return User(*record)
+
+    @classmethod
+    def username_available(cls, username):
+        try:
+            # Username is found, so it is unavailable
+            User.get_by_identifier(username, is_username=True)
+            return False
+        except LookupError:
+            # Username is not found, so it is available
+            return True
+
+    @property
+    def json(self):
+        return json.dumps({
+            "id": self.id,
+            "username": self.username,
+            "name": self.name,
+            "email": self.email
+        })

--- a/src/rickbox/util/validators.py
+++ b/src/rickbox/util/validators.py
@@ -1,0 +1,11 @@
+def validate_id(id_value):
+    if id_value is None:
+        raise ValueError('`id_value` cannot be None.')
+
+    # Lazy assertion that the id is actually an integer
+    id_value = int(id_value)
+
+    if id_value < 0:
+        raise ValueError('`id_value` must be non-negative.')
+
+    return id_value


### PR DESCRIPTION
Add User model with basic functionality
Implement callproc pass-through in database_helper
Add some basic endpoints to access and create User records

Note: The included endpoints are just POC. They will be rewritten to conform to the RAML upon approval of the User model, then included in a subsequent PR. 